### PR TITLE
Fix undefined being rendered in HTML output

### DIFF
--- a/src/components/AppCodeOutput.vue
+++ b/src/components/AppCodeOutput.vue
@@ -97,7 +97,7 @@ button:focus {
 }`;
     },
     buttonHtmlOutput() {
-      if (!this.rightoptions.button) return;
+      if (!this.rightoptions.button) return '';
       return `
     <button>
       When a hero comes along


### PR DESCRIPTION
- This commits removes the undefined string placed in the HTML output by
returning empty string '' when there is no hero button.

**Before**
![image](https://user-images.githubusercontent.com/2782816/80396055-b4905680-8879-11ea-822a-497a0ad51573.png)

**After**
![image](https://user-images.githubusercontent.com/2782816/80396074-ba863780-8879-11ea-9d27-f367d04eb486.png)
