### PR TITLE
Code drawer improvements

### DIFF
--- a/src/components/AppCodeDrawer.vue
+++ b/src/components/AppCodeDrawer.vue
@@ -49,6 +49,7 @@ export default {
 .ant-drawer-wrapper-body {
   background: #111 !important;
   color: rgb(159, 203, 211) !important;
+  height: 100%; // to allow scrolling in the code drawer
 }
 
 .ant-drawer-title {

--- a/src/components/AppCodeOutput.vue
+++ b/src/components/AppCodeOutput.vue
@@ -2,8 +2,9 @@
   <div>
     <div ref="code">
       <h3>CSS</h3>
-      <pre class="code css">
+      <pre class="code">
         {{ mastheadOutput }}
+
         <slot v-if="rightoptions.button">
           {{ buttonOutput }}
         </slot>
@@ -114,19 +115,23 @@ button:focus {
   },
   methods: {
     copy() {
-      let text = this.$refs.code,
-        range,
+      let range,
         selection;
+      let codeNodes = this.$refs.code.getElementsByClassName("code");
+
       if (document.body.createTextRange) {
         range = document.body.createTextRange();
-        range.moveToElementText(text);
-        range.select();
+        codeNodes.forEach(el => {
+          range.moveToElementText(el);
+          range.select();
+        });
       } else if (window.getSelection) {
         selection = window.getSelection();
-        range = document.createRange();
-        range.selectNodeContents(text);
-        selection.removeAllRanges();
-        selection.addRange(range);
+        codeNodes.forEach(el => {
+          range = document.createRange();
+          range.selectNodeContents(el);
+          selection.addRange(range);
+        });
       }
 
       let copied = document.execCommand("copy");

--- a/src/components/AppCodeOutput.vue
+++ b/src/components/AppCodeOutput.vue
@@ -2,11 +2,11 @@
   <div>
     <div ref="code">
       <h3>CSS</h3>
-      <pre class="code">
+      <pre class="code css">
         {{ mastheadOutput }}
-      </pre>
-      <pre class="code" v-if="rightoptions.button">
-        {{ buttonOutput }}
+        <slot v-if="rightoptions.button">
+          {{ buttonOutput }}
+        </slot>
       </pre>
 
       <h3>HTML</h3>


### PR DESCRIPTION
That's a pretty helpful project!

I played around with it and decided to add some improvements to the code drawer, hopefully they will be useful.

This PR:

- makes the drawer scrollable, which would allow users to select the text manually. with current implementation, you can't scroll past the copy button
- makes the copy button to copy only code, skipping the "CSS" and "HTML" headers. Also, CSS for hero button now included into the whole CSS code section.